### PR TITLE
Promote dev → main: runtime-partial-inline fix for 0.9.0

### DIFF
--- a/src/hott/HotStaticBuilder.ts
+++ b/src/hott/HotStaticBuilder.ts
@@ -149,6 +149,13 @@ export class HotStaticBuilder
 	readonly routeChunks: Map<string, string> = new Map ();
 	/** HS090-15 build-time expansion: shared across partial expansions. */
 	private readonly moduleRegistry: Map<string, SandboxModule> = new Map ();
+	/**
+	 * v0.9.1 runtime-partial-inline: compiled source of each partial
+	 * reachable from any Hot.include(path, args) call site, keyed by
+	 * absolute file path. Reused across call sites so identical partials
+	 * don't recompile.
+	 */
+	private readonly runtimePartialSources: Map<string, HottModule> = new Map ();
 	/** HS090-15: shell-head-hoisted <link>/<script> references from modules. */
 	private readonly shellCss: string[] = [];
 	private readonly shellJs: string[] = [];
@@ -194,8 +201,9 @@ export class HotStaticBuilder
 		// 1c. copy web.{app}.jsFiles + queue them for the shell head.
 		await this.resolveJsFiles ();
 
-		// 2. resolve partials (HS090-15).
+		// 2. resolve partials (HS090-15 + v0.9.1 runtime-inline).
 		await this.resolvePartials ();
+		await this.prepareRuntimePartials ();
 
 		// 3. staticRender routes — HS090-19.
 		await this.prerenderStaticRoutes ();
@@ -593,7 +601,7 @@ export class HotStaticBuilder
 			this.warnings.push ({
 				code: "hs090-15/expand-fallback",
 				message: `Build-time expansion of ${work.src} (id="${work.stashId}") failed: ${String ((err as Error).message || err)}. ` +
-					`Falling back to raw-template inline.`,
+					`Falling back to runtime-partial-inline (caller's runtime scope supplies values).`,
 				where: `web.${work.fromApp}`
 			});
 			return (null);
@@ -926,6 +934,14 @@ export class HotStaticBuilder
 					appName, cr, templateId, preload as "lazy" | "never"
 				);
 
+				if (this.opts.verbose)
+				{
+					await fsp.writeFile (
+						ppath.resolve (this.opts.cwd, `__chunk_dump_${sluggifyPath (cr.route.path)}.js`),
+						chunkSource
+					);
+				}
+
 				// Bundle through esbuild so preamble TS/JSX/ES2023+ syntax
 				// gets downleveled consistently with app.js.
 				const result = await esbuild.build ({
@@ -968,7 +984,8 @@ export class HotStaticBuilder
 	{
 		const templateLiteral: string = JSON.stringify (cr.module.template);
 		const scripts: string = JSON.stringify (cr.module.scripts);
-		const preambleFn: string = preambleToAsyncFn (cr.module.preamble);
+		const inlinedPreamble: string = this.buildRuntimeInlinedPreamble (cr, appName);
+		const preambleFn: string = preambleToAsyncFn (inlinedPreamble);
 
 		return ([
 			`(function () {`,
@@ -998,6 +1015,129 @@ export class HotStaticBuilder
 			`  });`,
 			`})();`
 		].join ("\n"));
+	}
+
+	/**
+	 * v0.9.1 runtime-partial-inline: compile every partial referenced
+	 * by a Hot.include(path, args) call site and cache its HottModule.
+	 * generateEntrySource() splices these into each caller's preamble
+	 * as local async functions so the partial body runs at mount with
+	 * the caller's live variables in scope.
+	 *
+	 * Partials with no args (argless Hot.include) continue to use the
+	 * HS090-15 stash path — this method leaves those alone.
+	 */
+	async prepareRuntimePartials (): Promise<void>
+	{
+		for (const [appName, compiled] of this.compiledRoutes.entries ())
+		{
+			for (const cr of compiled)
+			{
+				for (const call of cr.module.partialCalls)
+				{
+					if (call.argsExprText === null)
+						continue; // argless — use stash.
+
+					const abs: string = this.resolvePartialPath (call.path, appName);
+					if (this.runtimePartialSources.has (abs))
+						continue;
+					if (!fs.existsSync (abs))
+					{
+						this.warnings.push ({
+							code: "hs091/partial-not-found",
+							message: `Runtime-inline partial ${call.path} not found at ${abs}.`,
+							where: `web.${appName}`
+						});
+						continue;
+					}
+					const source: string = await fsp.readFile (abs, "utf8");
+					const mod: HottModule = compileSource (source, { filename: abs });
+					this.runtimePartialSources.set (abs, mod);
+					for (const w of mod.warnings)
+						this.warnings.push ({ code: w.code, message: w.message, where: abs });
+				}
+			}
+		}
+	}
+
+	/**
+	 * Given a route's compiled preamble source, rewrite every
+	 * `hotCtx.__includePartial(stashId, argsExpr)` placeholder (emitted
+	 * by rewrite-preamble when Hot.include has args) into a call to a
+	 * locally-declared async function. Returns the modified body plus
+	 * the function declarations to prepend inside the preamble closure.
+	 */
+	private buildRuntimeInlinedPreamble (
+		cr: CompiledRoute,
+		appName: string,
+		ctx: string = "hotCtx"
+	): string
+	{
+		const declarations: string[] = [];
+		const declared: Set<string> = new Set ();
+		const decl = (fnName: string, compiledPartial: HottModule, argKeys: string[]): void =>
+		{
+			if (declared.has (fnName)) return;
+			declared.add (fnName);
+			// `let` (not `const`) because legacy partials often reassign
+			// their args — `if (typeof name === "undefined") name = "...";`
+			// is idiomatic .hott. Also pulled from `__args` directly
+			// (not via hotCtx) since hotCtx is the single arg of the
+			// wrapper function.
+			const destructure: string = argKeys.length > 0
+				? `let { ${argKeys.join (", ")} } = __args || {};`
+				: "";
+			// The partial's compiled preamble uses `hotCtx` too; it
+			// receives the same hotCtx the caller has, so its echoes
+			// land in the caller's buffer naturally. __args is a local
+			// on hotCtx only for the destructure above — we pass it
+			// in via a tiny shim below to avoid polluting the partial.
+			declarations.push (
+				`async function ${fnName}(hotCtx, __args) {\n` +
+				`  ${destructure}\n` +
+				`  ${compiledPartial.preamble}\n` +
+				`}`
+			);
+		};
+
+		let body: string = cr.module.preamble;
+
+		// Replace every `await hotCtx.__includePartial("<id>", <expr>)`
+		// occurrence. Paren-matching regex (non-greedy) is sufficient
+		// for the output rewrite-preamble emits — it's always one line.
+		for (const call of cr.module.partialCalls)
+		{
+			if (call.argsExprText === null)
+				continue;
+
+			const abs: string = this.resolvePartialPath (call.path, appName);
+			const partial: HottModule | undefined = this.runtimePartialSources.get (abs);
+			if (!partial)
+				continue;
+
+			const argKeys: string[] = call.args ? Object.keys (call.args) : [];
+			const fnName: string = `__hs_p_${safeFnName (call.stashId)}`;
+			decl (fnName, partial, argKeys);
+
+			// Rewrite the placeholder in body: replace the whole
+			// `await hotCtx.__includePartial("<id>", <argsExpr>)`
+			// with `await <fnName>(hotCtx, <argsExpr>)`.
+			const placeholderStart: string = `await ${ctx}.__includePartial(${JSON.stringify (call.stashId)}, `;
+			let idx: number = body.indexOf (placeholderStart);
+			while (idx !== -1)
+			{
+				const argsStart: number = idx + placeholderStart.length;
+				const argsEnd: number = findMatchingClose (body, argsStart);
+				if (argsEnd === -1)
+					break;
+				const argsExpr: string = body.substring (argsStart, argsEnd);
+				const replacement: string = `await ${fnName}(${ctx}, ${argsExpr})`;
+				body = body.substring (0, idx) + replacement + body.substring (argsEnd + 1);
+				idx = body.indexOf (placeholderStart, idx + replacement.length);
+			}
+		}
+
+		return ([ ...declarations, body ].join ("\n"));
 	}
 
 	async bundleAppJs (): Promise<{ path: string; hash: string; size: number }>
@@ -1141,7 +1281,8 @@ export class HotStaticBuilder
 				}
 
 				const templateId: string = templateIdForRoute (appName, cr.route.path);
-				const preambleFn: string = preambleToAsyncFn (cr.module.preamble);
+				const inlinedPreamble: string = this.buildRuntimeInlinedPreamble (cr, appName);
+				const preambleFn: string = preambleToAsyncFn (inlinedPreamble);
 				const scripts: string = JSON.stringify (cr.module.scripts);
 				const preloadJson: string = JSON.stringify (preload);
 
@@ -1522,6 +1663,79 @@ function sluggifyPath (routePath: string): string
 {
 	if (routePath === "/") return ("root");
 	return (routePath.replace (/^\/+/, "").replace (/\/+$/, "").replace (/[^a-zA-Z0-9_\-]/g, "-").toLowerCase () || "root");
+}
+
+/**
+ * Turn a partial stashId (e.g. `header#44136fa355`) into a JS-safe
+ * identifier for a generated function name.
+ */
+function safeFnName (stashId: string): string
+{
+	return (stashId.replace (/[^a-zA-Z0-9_]/g, "_"));
+}
+
+/**
+ * Given an open position right AFTER an opening `(`, find the index of
+ * the matching close `)`. Respects basic string literals (single/double/
+ * backtick with escapes) and nested parens. Returns -1 if no match.
+ * Used to slice the args expression out of a
+ * `hotCtx.__includePartial("id", <argsExpr>)` placeholder.
+ */
+function findMatchingClose (src: string, start: number): number
+{
+	let depth: number = 1;
+	let i: number = start;
+	const len: number = src.length;
+	while (i < len)
+	{
+		const ch: string = src.charAt (i);
+		if (ch === "\"" || ch === "'" || ch === "`")
+		{
+			i = skipStringFrom (src, i, ch);
+			continue;
+		}
+		if (ch === "(") depth++;
+		else if (ch === ")")
+		{
+			depth--;
+			if (depth === 0) return (i);
+		}
+		i++;
+	}
+	return (-1);
+}
+
+function skipStringFrom (src: string, start: number, quote: string): number
+{
+	let i: number = start + 1;
+	const len: number = src.length;
+	while (i < len)
+	{
+		const ch: string = src.charAt (i);
+		if (ch === "\\") { i += 2; continue; }
+		if (ch === quote) return (i + 1);
+		// Template literal ${ ... } interpolations — skip to matching }
+		if (quote === "`" && ch === "$" && src.charAt (i + 1) === "{")
+		{
+			i += 2;
+			let braceDepth: number = 1;
+			while (i < len && braceDepth > 0)
+			{
+				const c: string = src.charAt (i);
+				if (c === "\"" || c === "'" || c === "`")
+				{
+					i = skipStringFrom (src, i, c);
+					continue;
+				}
+				if (c === "{") braceDepth++;
+				else if (c === "}") braceDepth--;
+				i++;
+			}
+			continue;
+		}
+		i++;
+	}
+	return (len);
 }
 
 function escapeAttr (s: string): string

--- a/src/hott/rewrite-preamble.ts
+++ b/src/hott/rewrite-preamble.ts
@@ -39,6 +39,12 @@ export interface PartialCall
 	/** Literal args object if the call site passed one, else null. */
 	args: Record<string, any> | null;
 	/**
+	 * Verbatim source text of the args expression. Runtime-inline uses
+	 * this so caller-scope live variables (e.g. a runtime-fetched
+	 * `config`) flow into the partial naturally.
+	 */
+	argsExprText: string | null;
+	/**
 	 * Stable stash id the compiled preamble references via
 	 * hotCtx.includeStash(...). Derived from path for plain literal
 	 * includes, or path + args-hash when args are present so that two
@@ -232,33 +238,49 @@ function rewriteIncludeCall (
 			partials.push (stringLiteral);
 		}
 
-		// Check for a second-arg literal object — admin-panel, userroute
-		// etc. pass { TITLE, SIDEBAR_ITEMS } here.
+		// Capture the second-arg expression. If it's literal we also
+		// materialise the values so the builder can try build-time
+		// expansion; if that fails (or args were non-literal), the
+		// builder swaps in a runtime-inline partial call whose args
+		// use the verbatim source text so caller-scope variables flow
+		// into the partial naturally.
 		let argsValue: Record<string, any> | null = null;
+		let argsExprText: string | null = null;
 		if (args.length >= 2)
 		{
 			const second = args[1];
+			argsExprText = second.getText ();
 			if (isLiteralAst (second))
 			{
 				argsValue = materialiseLiteral (second) as Record<string, any>;
 			}
-			else
-			{
-				warnings.push ({
-					code: "hott/hot-include-dynamic-args",
-					message: "Hot.include() called with a non-literal args object; partial will not be build-time expanded.",
-					start: call.getStart (),
-					end: call.getEnd ()
-				});
-			}
 		}
 
 		const stashId: string = stashIdFor (stringLiteral, argsValue);
-		partialCalls.push ({ path: stringLiteral, args: argsValue, stashId });
-		// Wrap in hotCtx.echo so the partial HTML actually lands in the
-		// mount host. The legacy Hot.include appended to Hot.Output as a
-		// side effect; our v0.9.0 equivalent is echo-into-host.
-		call.replaceWithText (`${ctx}.echo(${ctx}.includeStash(${JSON.stringify (stashId)}))`);
+		partialCalls.push ({ path: stringLiteral, args: argsValue, argsExprText, stashId });
+
+		// Emit a placeholder the builder rewrites during entry code-gen:
+		//   → hotCtx.echo(hotCtx.includeStash('<id>'))          (argless)
+		//   → await hotCtx.__includePartial('<id>', <argsExpr>) (with args)
+		// The __includePartial placeholder carries the live args
+		// expression text so runtime-inline can invoke a local fn. When
+		// the original call is already inside an `await` expression we
+		// replace that parent so the final placeholder has exactly one
+		// leading `await`, not two.
+		if (argsExprText !== null)
+		{
+			const parent = call.getParent ();
+			const targetNode = (parent && parent.getKind () === SyntaxKind.AwaitExpression)
+				? parent
+				: call;
+			targetNode.replaceWithText (
+				`await ${ctx}.__includePartial(${JSON.stringify (stashId)}, ${argsExprText})`
+			);
+		}
+		else
+		{
+			call.replaceWithText (`${ctx}.echo(${ctx}.includeStash(${JSON.stringify (stashId)}))`);
+		}
 		return;
 	}
 

--- a/src/hott/tokenize.ts
+++ b/src/hott/tokenize.ts
@@ -91,6 +91,19 @@ function findPreambleClose (src: string, bodyStart: number): number
 {
 	const len: number = src.length;
 	let i: number = bodyStart;
+	// Tracks the last non-whitespace, non-comment byte seen. Used to
+	// disambiguate `/` between division (after ident/number/`)`) and
+	// regex literal (after operator / keyword / opening delim). Without
+	// this, regexes like `value.replace(/\"/g, ...)` — where the `"`
+	// inside the regex looks like a string start — corrupt the preamble
+	// close scan.
+	let prevSignificant: string = "";
+
+	const markSig = (c: string): void =>
+	{
+		if (c === " " || c === "\t" || c === "\n" || c === "\r") return;
+		prevSignificant = c;
+	};
 
 	while (i < len)
 	{
@@ -99,6 +112,7 @@ function findPreambleClose (src: string, bodyStart: number): number
 		if (ch === "\"" || ch === "'" || ch === "`")
 		{
 			i = skipStringLiteral (src, i, ch);
+			prevSignificant = ch;
 			continue;
 		}
 
@@ -108,14 +122,22 @@ function findPreambleClose (src: string, bodyStart: number): number
 
 			if (n === "/")
 			{
-				// Line comment.
 				i = skipUntil (src, i + 2, "\n");
 				continue;
 			}
 			if (n === "*")
 			{
-				// Block comment.
 				i = skipBlockComment (src, i + 2);
+				continue;
+			}
+
+			// Regex literal vs division. Regex is valid when the
+			// preceding significant char is an operator, delimiter, or
+			// empty (start of body).
+			if (isRegexAllowedAfter (prevSignificant))
+			{
+				i = skipRegexLiteral (src, i);
+				prevSignificant = "/";
 				continue;
 			}
 		}
@@ -123,10 +145,43 @@ function findPreambleClose (src: string, bodyStart: number): number
 		if (ch === "*" && src.charAt (i + 1) === ">")
 			return (i);
 
+		markSig (ch);
 		i++;
 	}
 
 	return (-1);
+}
+
+function isRegexAllowedAfter (c: string): boolean
+{
+	if (c === "") return (true);
+	// Identifier chars / digits / ) ] → division context.
+	if (/[A-Za-z0-9_$)\]]/.test (c)) return (false);
+	return (true);
+}
+
+function skipRegexLiteral (src: string, start: number): number
+{
+	const len: number = src.length;
+	let i: number = start + 1;
+	let inClass: boolean = false;
+	while (i < len)
+	{
+		const ch: string = src.charAt (i);
+		if (ch === "\\") { i += 2; continue; }
+		if (ch === "[") inClass = true;
+		else if (ch === "]") inClass = false;
+		else if (ch === "/" && !inClass)
+		{
+			// Consume flags.
+			let j: number = i + 1;
+			while (j < len && /[gimsuy]/.test (src.charAt (j))) j++;
+			return (j);
+		}
+		else if (ch === "\n") return (i); // unterminated; bail.
+		i++;
+	}
+	return (len);
 }
 
 function skipStringLiteral (src: string, start: number, quote: string): number

--- a/src/hott/types.ts
+++ b/src/hott/types.ts
@@ -30,15 +30,36 @@ export interface CompileWarning
 }
 
 /**
- * One captured literal Hot.include call. `args` is null when the site
- * passed no args or the args weren't a literal; the builder treats null
- * as "fall back to raw-template stash" and non-null as "build-time
- * expand against these args."
+ * One captured literal Hot.include call. `args` is the materialised
+ * literal args object (with `undefined` for any non-literal values),
+ * or `null` if the call site passed no args.
+ *
+ * Policy for the builder (HS090-15 + runtime-partial-inline, v0.9.1+):
+ *  - args == null:            raw-template stash inline (cheap, sync).
+ *  - args is fully literal:   try build-time expansion → bake HTML into
+ *                             the stash. Falls through to the next row
+ *                             if the partial's preamble needs runtime
+ *                             APIs (hotCtx.getJSON, cookies, etc.).
+ *  - args partially literal
+ *    OR expansion fails:      runtime-inline the partial's compiled
+ *                             preamble into the caller's preamble as
+ *                             a local async function invoked with
+ *                             argsExprText. Args destructure into the
+ *                             partial's scope; the caller's runtime
+ *                             variables flow through naturally.
  */
 export interface PartialCallRecord
 {
 	path: string;
 	args: Record<string, any> | null;
+	/**
+	 * Verbatim JavaScript source of the args object expression as it
+	 * appeared in the caller's preamble. Used by runtime-partial-inline
+	 * to emit `await __partial_N(hotCtx, <argsExprText>)` so caller's
+	 * live variables flow into the partial without losing references.
+	 * Null when no args were passed.
+	 */
+	argsExprText: string | null;
 	stashId: string;
 }
 

--- a/tests/hott/PartialBuildExpand.ts
+++ b/tests/hott/PartialBuildExpand.ts
@@ -254,4 +254,54 @@ describe ("v0.9.0 — HS090-15 build-time partial expansion (admin-panel shape)"
 		}
 		finally { await fsp.rm (tmp, { recursive: true, force: true }); }
 	});
+
+	/**
+	 * Runtime-partial-inline.
+	 *
+	 * When build-time expansion fails (e.g. the partial reads runtime-only
+	 * values like hotCtx.getJSON or a caller-scope variable), the builder
+	 * emits the partial as a local async function in the caller's preamble
+	 * with args destructured from `__args`. Caller-scope live variables
+	 * (e.g. config fetched at runtime) flow into the partial naturally.
+	 */
+	it ("inlines the partial as a local async fn when caller passes runtime args", async () =>
+	{
+		const tmp: string = await fsp.mkdtemp (ppath.join (os.tmpdir (), "hs091-inline-"));
+		try
+		{
+			const pub: string = ppath.join (tmp, "public");
+			await fsp.mkdir (ppath.join (pub, "components"), { recursive: true });
+
+			await fsp.writeFile (ppath.join (pub, "components", "badge.hott"),
+				"<* Hot.echo(`Hello ${config.name}`); *>"
+			);
+			await fsp.writeFile (ppath.join (pub, "index.hott"),
+				"<* const config = await Hot.getJSON('/c.json');\n" +
+				"   await Hot.include('./components/badge.hott', { config: config }); *>\n" +
+				"<main></main>"
+			);
+
+			const site: HotSite = {
+				name: "rti",
+				web: { "rti": { mainUrl: "/", routes: [
+					{ path: "/p", file: "./public/index.hott", preload: "lazy" }
+				] } }
+			};
+			const out: string = ppath.join (tmp, "dist");
+			const builder = new HotStaticBuilder (site, { cwd: tmp, out, mode: "development" });
+			await builder.build ();
+
+			const files = await fsp.readdir (out);
+			const chunkFile = files.find (f => f.startsWith ("app-route-p."));
+			expect (chunkFile, `expected lazy chunk, got ${files.join (",")}`).to.be.a ("string");
+
+			const chunkJs = await fsp.readFile (ppath.join (out, chunkFile!), "utf8");
+
+			expect (chunkJs).to.match (/async function __hs_p_components_badge/);
+			expect (chunkJs).to.not.include ("await await __hs_p_");
+			expect (chunkJs).to.not.include ("__includePartial");
+			expect (chunkJs).to.match (/await __hs_p_components_badge[\w]+\(/);
+		}
+		finally { await fsp.rm (tmp, { recursive: true, force: true }); }
+	});
 });


### PR DESCRIPTION
Triggers the GitLab publish pipeline so hotstaq@0.9.0 (with the runtime-partial-inline + tokenizer fixes folded in) lands on npm.

See #171 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)