### PR TITLE
v0.9.4: graceful Ctrl-C shutdown with 5s force-quit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotstaq",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A friendly web framework that fits nicely into devops and CI/CD pipelines.",
   "bin": {
     "hotstaq": "./bin/hotstaq"

--- a/src/HotHTTPServer.ts
+++ b/src/HotHTTPServer.ts
@@ -1643,6 +1643,19 @@ export class HotHTTPServer extends HotServer
 						this.logger.info (`MCP server listening on route "${this.mcpServer.route}"`);
 					}
 
+					// Track whether a shutdown is already in progress so a
+					// second Ctrl-C / SIGTERM can hard-quit instead of
+					// waiting on a hung close().
+					let shutdownInFlight: boolean = false;
+					let forceQuitTimer: NodeJS.Timeout = null;
+
+					// Hard-quit after this many ms even if listener.close()
+					// hasn't returned. Default 5s; override via the
+					// HOTSTAQ_SHUTDOWN_FORCE_MS env var (any positive int)
+					// or set to 0 to wait forever (the old behaviour).
+					const forceQuitMsRaw: number = parseInt (process.env["HOTSTAQ_SHUTDOWN_FORCE_MS"] || "5000", 10);
+					const forceQuitMs: number = (Number.isFinite (forceQuitMsRaw) && forceQuitMsRaw >= 0) ? forceQuitMsRaw : 5000;
+
 					let requestReporter = () =>
 					{
 						let numRequests: number = Object.keys(this.activeRequests).length;
@@ -1653,14 +1666,52 @@ export class HotHTTPServer extends HotServer
 
 							this.logger.info (`Finished processing all requests...`);
 
-							return;
+							// listener.close() resolved AND the in-flight
+							// counter is empty. We're done — let the
+							// process exit instead of hanging on stray
+							// keep-alive sockets / DB clients / etc.
+							if (forceQuitTimer != null)
+								clearTimeout (forceQuitTimer);
+
+							process.exit (0);
 						}
 
 						this.logger.info (`Still processing ${numRequests} requests...`);
 					};
 					let sigHandler = (typeReceived: string, serverType: string, listener: any) =>
 						{
+							// Second Ctrl-C / SIGTERM during a shutdown that
+							// the framework can't drain on its own — give
+							// the developer an escape hatch instead of
+							// stranding them in the terminal.
+							if (shutdownInFlight === true)
+							{
+								this.logger.info (`${typeReceived} received again; forcing immediate exit.`);
+								process.exit (130);
+							}
+
+							shutdownInFlight = true;
+
 							this.logger.info (`${typeReceived} signal received: Stopping ${serverType} server. Data loss and partial database writes can occur if this is stopped prematurely.`);
+
+							// Force-quit if graceful shutdown stalls. Common
+							// cause is open HTTP/1.1 keep-alive sockets that
+							// listener.close() refuses to terminate, but it
+							// also catches DB clients, Garnet pub/sub,
+							// websocket holds, etc.
+							if (forceQuitMs > 0)
+							{
+								forceQuitTimer = setTimeout (() =>
+								{
+									this.logger.info (`Graceful shutdown exceeded ${forceQuitMs}ms; forcing exit.`);
+									process.exit (1);
+								}, forceQuitMs);
+								// Don't keep the event loop alive just for
+								// this timer — if the only thing left is
+								// the timer, we want Node to exit naturally.
+								if (typeof forceQuitTimer.unref === "function")
+									forceQuitTimer.unref ();
+							}
 
 							listener.close (() => {
 								this.logger.info(`${serverType} server stopped. No longer listening for any new incoming requests...`);
@@ -1670,6 +1721,14 @@ export class HotHTTPServer extends HotServer
 									requestReporter ();
 								}, 2000);
 							});
+
+							// Aggressive: immediately destroy any open
+							// keep-alive sockets that haven't been claimed
+							// by an in-flight request. listener.close()
+							// politely waits for them to time out (default
+							// 65s); we'd rather drop them and exit on time.
+							if (typeof listener.closeIdleConnections === "function")
+								listener.closeIdleConnections ();
 						};
 
 					if (this.ssl.cert === "")

--- a/src/HotStaq.ts
+++ b/src/HotStaq.ts
@@ -238,7 +238,7 @@ export class HotStaq implements IHotStaq
 	/**
 	 * The current version of HotStaq.
 	 */
-	static version: string = "0.9.3";
+	static version: string = "0.9.4";
 	/**
 	 * Indicates if this is a web build.
 	 */


### PR DESCRIPTION
## Summary
Dev-server `SIGINT`/`SIGTERM` could log \"Finished processing all requests…\" and then hang forever — the reporter cleared its interval but nothing called `process.exit()`. Open keep-alive sockets, DB clients, websocket holders, and Garnet connections kept the event loop alive indefinitely. Common workaround was \`kill -9\`.

Three changes in HotHTTPServer.ts's signal handler:

1. **Exit on clean drain.** When the in-flight counter reaches 0, the reporter now calls \`process.exit(0)\` after logging \"Finished processing all requests…\".
2. **5-second force-quit.** A timer fires \`process.exit(1)\` after 5 s if the graceful path stalls. Knob: \`HOTSTAQ_SHUTDOWN_FORCE_MS\` env var. Set to 0 to restore the old wait-forever behaviour. Timer is \`unref()\`-ed so a clean shutdown that finishes faster doesn't get killed.
3. **Double-tap escape.** Second \`SIGINT\`/\`SIGTERM\` during shutdown bypasses everything and exits 130 immediately.

Plus: call \`listener.closeIdleConnections()\` (Node 18.2+) so unused HTTP/1.1 keep-alives drop immediately instead of waiting on the default 5 s \`keepAliveTimeout\`. That alone fixes the common case where an idle browser tab made the listener look hung.

The HTTPS code path uses the same \`sigHandler\` closure, so all three fixes apply there too.

## Test plan
- [ ] Manual: \`npm run develop\` on any HotStaq app, hit Ctrl-C while a browser tab is connected — should exit cleanly within 5 s.
- [ ] Manual: open a long-poll request, Ctrl-C — \"Still processing 1 requests…\" → \"Finished processing all requests…\" → exit 0.
- [ ] Manual: simulate a hung handler (sleep), Ctrl-C — should hard-exit at 5 s with code 1.
- [ ] Manual: \`HOTSTAQ_SHUTDOWN_FORCE_MS=0 npm run develop\` then Ctrl-C — wait-forever path still works for advanced shutdown debugging.
- [ ] Manual: Ctrl-C twice in rapid succession — second one exits 130 immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)